### PR TITLE
Add output redirection and force output features (-o and -f flags)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ This Rust implementation covers the core functionality of the original `pv` util
 | Bar style (`-u`) | ✅ | 🔴 Not Implemented |
 | Extra display (`-x`) | ✅ | 🔴 Not Implemented |
 | Transfer stats (`-v`) | ✅ | 🔴 Not Implemented |
-| Force output (`-f`) | ✅ | 🔴 Not Implemented |
+| Force output (`-f`) | ✅ | ✅ Implemented |
 | Cursor positioning (`-c`) | ✅ | 🔴 Not Implemented |
 | **Data Transfer Features** |
-| Output to file (`-o`) | ✅ | 🔴 Not Implemented |
+| Output to file (`-o`) | ✅ | ✅ Implemented |
 | Rate limiting (`-L`) | ✅ | ✅ Implemented |
 | Buffer size control (`-B`) | ✅ | 🔴 Not Implemented |
 | No splice (`-C`) | ✅ | 🔴 Not Implemented |
@@ -80,8 +80,8 @@ This Rust implementation covers the core functionality of the original `pv` util
 - [x] Custom format strings (`-F`) - Essential for scripting and integration
 - [x] Numeric output (`-n`) - Important for automation
 - [x] Rate limiting (`-L`) - Common use case for bandwidth control  
-- [ ] Output to file (`-o`) - Basic I/O redirection
-- [ ] Force output (`-f`) - Important for non-terminal usage
+- [x] Output to file (`-o`) - Basic I/O redirection
+- [x] Force output (`-f`) - Important for non-terminal usage
 - [ ] Quiet mode (`-q`) - Essential for silent operation
 
 **Medium Priority (Enhanced Display):**
@@ -100,7 +100,7 @@ This Rust implementation covers the core functionality of the original `pv` util
 
 ### Summary
 
-The current implementation covers exactly **52%** of the standard `pv` features (24 out of 46 options). It successfully implements the core progress monitoring functionality including custom format strings, numeric output, and rate limiting, but lacks many advanced features that make the original `pv` versatile for different use cases.
+The current implementation covers exactly **57%** of the standard `pv` features (26 out of 46 options). It successfully implements the core progress monitoring functionality including custom format strings, numeric output, rate limiting, output to file, and force output, but lacks many advanced features that make the original `pv` versatile for different use cases.
 
 ### Out of Scope Features
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use indicatif::{ProgressBar, ProgressStyle};
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use std::fs::File;
 use std::io;
 use std::io::{ErrorKind, Read, Write};
@@ -80,7 +80,6 @@ struct PipeViewConfig {
     #[arg(short = 'O')]
     skip_output_errors: bool,
     /// Input filenames. Use -, /dev/stdin, or nothing, to use stdin
-    #[arg(short = 'f')]
     input_filenames: Vec<String>,
     /// Show message every N seconds instead of once per block (useful for high throughput streams)
     #[arg(short = 'i')]
@@ -112,6 +111,12 @@ struct PipeViewConfig {
     /// Rate limit data transfer to RATE bytes per second (k/m/g/t suffixes allowed)
     #[arg(short = 'L', long = "rate-limit", value_parser = parse_rate_limit)]
     rate_limit: Option<u64>,
+    /// Output to file instead of stdout
+    #[arg(short = 'o', long = "output")]
+    output_file: Option<String>,
+    /// Force output (show progress even if not connected to terminal)
+    #[arg(short = 'f', long = "force")]
+    force_output: bool,
 }
 
 fn main() {
@@ -153,9 +158,19 @@ fn main() {
             })
     };
 
+    let sink: Box<dyn Write> = if let Some(ref output_path) = matches.output_file {
+        // Output to file
+        Box::new(io::BufWriter::new(
+            File::create(output_path).expect("Failed to create output file"),
+        ))
+    } else {
+        // Output to stdout
+        Box::new(io::BufWriter::new(io::stdout()))
+    };
+
     PipeView {
-        source: sources,                                  // Source
-        sink: Box::new(io::BufWriter::new(io::stdout())), // Sink
+        source: sources, // Source
+        sink,            // Sink
         progress: PipeView::progress_from_options(&matches),
         line_mode: if matches.line_mode {
             LineMode::Line(if matches.null { 0 } else { 10 }) // default to unix newline
@@ -377,6 +392,10 @@ impl PipeView {
             if let Some(sec) = conf.interval {
                 progress.enable_steady_tick(Duration::from_secs_f64(sec));
             }
+            // Force output to stderr even when not connected to terminal
+            if conf.force_output {
+                progress.set_draw_target(ProgressDrawTarget::stderr());
+            }
             return progress;
         }
         let mut style = match conf.size {
@@ -453,6 +472,12 @@ impl PipeView {
             progress.enable_steady_tick(Duration::from_secs_f64(sec));
         }
         progress.set_style(style);
+
+        // Force output to stderr even when not connected to terminal
+        if conf.force_output {
+            progress.set_draw_target(indicatif::ProgressDrawTarget::stderr());
+        }
+
         progress
     }
 

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -206,11 +206,7 @@ fn test_special_characters_in_name() {
 
 #[test]
 fn test_nonexistent_file() {
-    pv_cmd()
-        .arg("-f")
-        .arg("/nonexistent/file/path")
-        .assert()
-        .failure(); // Should fail with non-existent file
+    pv_cmd().arg("/nonexistent/file/path").assert().failure(); // Should fail with non-existent file
 }
 
 #[test]

--- a/tests/format_tests.rs
+++ b/tests/format_tests.rs
@@ -252,7 +252,6 @@ fn test_format_with_file_input() {
         .arg("File: %{name}%{bytes}")
         .arg("-N")
         .arg("TestFile")
-        .arg("-f")
         .arg(test_file.path())
         .assert()
         .success()

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -33,7 +33,6 @@ fn test_file_input() {
     let test_file = create_test_file(test_data);
 
     pv_cmd()
-        .arg("-f")
         .arg(test_file.path())
         .assert()
         .success()
@@ -164,9 +163,7 @@ fn test_multiple_files() {
     let test_file2 = create_test_file(test_data2);
 
     pv_cmd()
-        .arg("-f")
         .arg(test_file1.path())
-        .arg("-f")
         .arg(test_file2.path())
         .assert()
         .success()
@@ -178,7 +175,6 @@ fn test_dash_as_stdin() {
     let test_data = "stdin test data";
 
     pv_cmd()
-        .arg("-f")
         .arg("-") // explicit stdin
         .write_stdin(test_data)
         .assert()

--- a/tests/numeric_tests.rs
+++ b/tests/numeric_tests.rs
@@ -194,7 +194,6 @@ fn test_numeric_with_file_input() {
     pv_cmd()
         .arg("-n") // numeric mode
         .arg("-b") // bytes
-        .arg("-f")
         .arg(test_file.path())
         .assert()
         .success()

--- a/tests/output_redirection_tests.rs
+++ b/tests/output_redirection_tests.rs
@@ -1,0 +1,233 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::io::{Read, Write};
+use tempfile::{NamedTempFile, TempDir};
+
+/// Helper function to create a test binary command
+fn pv_cmd() -> Command {
+    Command::cargo_bin("pv").unwrap()
+}
+
+/// Helper function to create test data of specified size
+fn create_test_data(size: usize) -> Vec<u8> {
+    (0..size).map(|i| (i % 256) as u8).collect()
+}
+
+/// Helper function to create test file with specific content
+fn create_test_file(content: &[u8]) -> NamedTempFile {
+    let mut file = NamedTempFile::new().unwrap();
+    file.write_all(content).unwrap();
+    file.flush().unwrap();
+    file
+}
+
+#[test]
+fn test_output_to_file_basic() {
+    let test_data = create_test_data(1024);
+    let temp_dir = TempDir::new().unwrap();
+    let output_file_path = temp_dir.path().join("output.dat");
+
+    let mut cmd = pv_cmd();
+    cmd.args(["-o"])
+        .arg(&output_file_path)
+        .write_stdin(test_data.clone())
+        .assert()
+        .success()
+        .stdout(""); // Should have no stdout when outputting to file
+
+    // Verify the file was created and has correct content
+    let mut file_content = Vec::new();
+    std::fs::File::open(&output_file_path)
+        .unwrap()
+        .read_to_end(&mut file_content)
+        .unwrap();
+
+    assert_eq!(file_content, test_data);
+}
+
+#[test]
+fn test_output_to_file_with_input_file() {
+    let test_data = create_test_data(512);
+    let input_file = create_test_file(&test_data);
+    let temp_dir = TempDir::new().unwrap();
+    let output_file_path = temp_dir.path().join("output.dat");
+
+    let mut cmd = pv_cmd();
+    cmd.arg(input_file.path())
+        .args(["-o"])
+        .arg(&output_file_path)
+        .assert()
+        .success()
+        .stdout(""); // Should have no stdout when outputting to file
+
+    // Verify the file was created and has correct content
+    let mut file_content = Vec::new();
+    std::fs::File::open(&output_file_path)
+        .unwrap()
+        .read_to_end(&mut file_content)
+        .unwrap();
+
+    assert_eq!(file_content, test_data);
+}
+
+#[test]
+fn test_output_to_file_with_progress() {
+    let test_data = create_test_data(256);
+    let temp_dir = TempDir::new().unwrap();
+    let output_file_path = temp_dir.path().join("output.dat");
+
+    let mut cmd = pv_cmd();
+    cmd.args(["-o"])
+        .arg(&output_file_path)
+        .args(["-t", "-b"]) // Enable timer and byte counter
+        .write_stdin(test_data.clone())
+        .assert()
+        .success()
+        .stdout(""); // Should have no stdout when outputting to file
+
+    // Verify the file was created and has correct content
+    let mut file_content = Vec::new();
+    std::fs::File::open(&output_file_path)
+        .unwrap()
+        .read_to_end(&mut file_content)
+        .unwrap();
+
+    assert_eq!(file_content, test_data);
+}
+
+#[test]
+fn test_output_to_file_overwrite() {
+    let test_data = create_test_data(100);
+    let temp_dir = TempDir::new().unwrap();
+    let output_file_path = temp_dir.path().join("output.dat");
+
+    // First write
+    let mut cmd = pv_cmd();
+    cmd.args(["-o"])
+        .arg(&output_file_path)
+        .write_stdin("first write")
+        .assert()
+        .success();
+
+    // Second write should overwrite
+    let mut cmd = pv_cmd();
+    cmd.args(["-o"])
+        .arg(&output_file_path)
+        .write_stdin(test_data.clone())
+        .assert()
+        .success();
+
+    // Verify the file has the second write's content
+    let mut file_content = Vec::new();
+    std::fs::File::open(&output_file_path)
+        .unwrap()
+        .read_to_end(&mut file_content)
+        .unwrap();
+
+    assert_eq!(file_content, test_data);
+}
+
+#[test]
+fn test_force_output_flag() {
+    let test_data = create_test_data(128);
+
+    let mut cmd = pv_cmd();
+    cmd.args(["-f", "-t"]) // Force output with timer
+        .write_stdin(test_data.clone())
+        .assert()
+        .success()
+        .stdout(test_data); // Should still output to stdout
+}
+
+#[test]
+fn test_force_output_with_numeric_mode() {
+    let test_data = create_test_data(64);
+
+    let mut cmd = pv_cmd();
+    cmd.args(["-f", "-n", "-b"]) // Force output with numeric mode
+        .write_stdin(test_data.clone())
+        .assert()
+        .success()
+        .stdout(test_data); // Should still output to stdout
+}
+
+#[test]
+fn test_output_file_error_handling() {
+    // Try to write to an invalid path (non-existent directory)
+    let mut cmd = pv_cmd();
+    cmd.args(["-o", "/nonexistent/directory/output.dat"])
+        .write_stdin("test")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Failed to create output file"));
+}
+
+#[test]
+fn test_output_file_with_line_mode() {
+    let test_data = "line1\nline2\nline3\n";
+    let temp_dir = TempDir::new().unwrap();
+    let output_file_path = temp_dir.path().join("output.txt");
+
+    let mut cmd = pv_cmd();
+    cmd.args(["-o"])
+        .arg(&output_file_path)
+        .args(["-l"]) // Line mode
+        .write_stdin(test_data)
+        .assert()
+        .success()
+        .stdout(""); // Should have no stdout when outputting to file
+
+    // Verify the file was created and has correct content
+    let file_content = std::fs::read_to_string(&output_file_path).unwrap();
+    assert_eq!(file_content, test_data);
+}
+
+#[test]
+fn test_output_file_with_rate_limiting() {
+    let test_data = create_test_data(256);
+    let temp_dir = TempDir::new().unwrap();
+    let output_file_path = temp_dir.path().join("output.dat");
+
+    let mut cmd = pv_cmd();
+    cmd.args(["-o"])
+        .arg(&output_file_path)
+        .args(["-L", "1m"]) // Rate limiting (1MB/s, should be fast)
+        .write_stdin(test_data.clone())
+        .assert()
+        .success()
+        .stdout(""); // Should have no stdout when outputting to file
+
+    // Verify the file was created and has correct content
+    let mut file_content = Vec::new();
+    std::fs::File::open(&output_file_path)
+        .unwrap()
+        .read_to_end(&mut file_content)
+        .unwrap();
+
+    assert_eq!(file_content, test_data);
+}
+
+#[test]
+fn test_force_output_and_output_file_combination() {
+    let test_data = create_test_data(128);
+    let temp_dir = TempDir::new().unwrap();
+    let output_file_path = temp_dir.path().join("output.dat");
+
+    let mut cmd = pv_cmd();
+    cmd.args(["-f", "-o"])
+        .arg(&output_file_path)
+        .args(["-t"]) // Timer for progress
+        .write_stdin(test_data.clone())
+        .assert()
+        .success()
+        .stdout(""); // Should have no stdout when outputting to file
+
+    // Verify the file was created and has correct content
+    let mut file_content = Vec::new();
+    std::fs::File::open(&output_file_path)
+        .unwrap()
+        .read_to_end(&mut file_content)
+        .unwrap();
+
+    assert_eq!(file_content, test_data);
+}

--- a/tests/rate_limiting_tests.rs
+++ b/tests/rate_limiting_tests.rs
@@ -102,7 +102,7 @@ fn test_rate_limit_with_file_input() {
 
     let expected_output = test_data.clone();
     let mut cmd = pv_cmd();
-    cmd.args(["-L", "512", "-f"])
+    cmd.args(["-L", "512"])
         .arg(temp_file.path())
         .assert()
         .success()


### PR DESCRIPTION
## Summary
This PR implements two important features from the original `pv` utility:
- **Output to file (-o/--output)**: Redirects data output to a specified file instead of stdout
- **Force output (-f/--force)**: Forces progress display even when not connected to a terminal

## Key Changes
- Fixed CLI argument conflicts by making input files positional arguments (matching original pv behavior)
- Added file output logic with proper error handling using `File::create()`
- Implemented force output using indicatif's `ProgressDrawTarget::stderr()`
- Added comprehensive integration tests (10 new tests covering various scenarios)
- Updated all existing tests to use positional arguments for input files instead of `-f` flag
- Updated README to reflect 57% feature coverage (26/46 features implemented)

## Technical Details
- The `-f` flag was previously incorrectly used for input file specification, conflicting with the standard pv force flag
- Input files are now properly handled as positional arguments, matching the original pv behavior
- File output creates a buffered writer to the specified path, with clear error messages on failure
- Force output works by setting the progress bar's draw target to stderr explicitly

## Test Plan
- ✅ All existing tests updated and passing
- ✅ 10 new integration tests covering:
  - Basic file output functionality
  - File output with input files
  - File output with progress indicators
  - File overwrite behavior
  - Force output flag functionality
  - Error handling for invalid paths
  - Integration with line mode and rate limiting
  - Combined force output and file output

## Compatibility
The implementation maintains full backward compatibility with existing functionality while adding these essential I/O redirection capabilities. The change to positional arguments actually improves compatibility with the original pv utility.

🤖 Generated with [Claude Code](https://claude.ai/code)