### PR TITLE
Fix binary stripping issue in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,13 +92,13 @@ jobs:
 
     - name: Strip binary (Linux/macOS)
       if: runner.os != 'Windows'
-      run: strip target/${{ matrix.target }}/release/pv*
+      run: strip target/${{ matrix.target }}/release/pv
 
     - name: Upload binary artifact
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.name }}
-        path: target/${{ matrix.target }}/release/pv*
+        path: target/${{ matrix.target }}/release/pv${{ runner.os == 'Windows' && '.exe' || '' }}
         retention-days: 30
 
   flatpak:


### PR DESCRIPTION
## Summary
Fixes the v0.4.0 release failure caused by strip command trying to process .d dependency files.

## Problem
The release workflow failed with:
```
strip: target/x86_64-unknown-linux-musl/release/pv.d: file format not recognized
```

## Solution
- Remove wildcard `pv*` from strip command that was matching both `pv` binary and `pv.d` files
- Use specific binary name `pv` for stripping
- Fix artifact upload path to properly handle Windows `.exe` extension

## Test plan
- [ ] Verify workflow passes CI
- [ ] Test with a new version tag to ensure release completes successfully

Fixes the failed v0.4.0 release workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)