### PR TITLE
Fix cross install conflict in musl build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,9 @@ jobs:
     - name: Build with cross (Linux musl)
       if: matrix.use_cross
       run: |
-        cargo install cross --git https://github.com/cross-rs/cross
+        if ! command -v cross &> /dev/null; then
+          cargo install cross --git https://github.com/cross-rs/cross
+        fi
         cross build --release --target ${{ matrix.target }}
 
     - name: Build native (Windows/macOS)


### PR DESCRIPTION
## Summary
- Fix musl build failure caused by cross installation conflict
- Add conditional check to only install cross if not already available
- Preserve cache benefits while avoiding cargo install errors

## Problem
The ubuntu-latest musl build was failing with:
```
error: binary `cross` already exists in destination
Add --force to overwrite
```

This happened because the workflow tried to install `cross` even when it was already cached from previous runs.

## Solution
Added a conditional check using `command -v cross` to only install cross if it's not already available. This:
- Preserves the performance benefits of caching
- Avoids the installation conflict error
- Maintains the same functionality

## Test plan
- [x] Verify the workflow change preserves existing behavior
- [ ] Test that the musl build succeeds in CI

🤖 Generated with [Claude Code](https://claude.ai/code)